### PR TITLE
feat: Filter out slots, add local date/times, rename namespace to 'oo'

### DIFF
--- a/geoSegment/geoSegment.js
+++ b/geoSegment/geoSegment.js
@@ -236,6 +236,11 @@ async function processSessionSeriesItems(items, segments) {
       continue;
     }
 
+    // Filter out high-frequency session data
+    if (item.data['beta:presentAsSlots'] || (item.data.superEvent && item.data.superEvent['beta:presentAsSlots'])) {
+      continue;
+    }
+
     /** @type {SessionSeriesData} */
     const sessionSeriesData = {
       ...item.data,

--- a/geoSegment/geoSegment.js
+++ b/geoSegment/geoSegment.js
@@ -237,7 +237,7 @@ async function processSessionSeriesItems(items, segments) {
     }
 
     // Filter out high-frequency session data
-    if (item.data['beta:presentAsSlots'] || (item.data.superEvent && item.data.superEvent['beta:presentAsSlots'])) {
+    if (item.data['beta:presentAsSlots'] === true || (item.data.superEvent && item.data.superEvent['beta:presentAsSlots'] === true)) {
       continue;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-objects-script",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "",
   "main": "walkRpde.js",
   "scripts": {


### PR DESCRIPTION
Small PR to:
- filter out data marked as `beta:presentAsSlots`
- add local properties to format date/times according to Open Object's spec
- update namespace from "imin" to "oo" for custom properties added by this script (to remove risk of future clashes)