### PR TITLE
chore: Make ESLint run on all files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "open-objects-script",
-  "version": "1.5.0",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "walkRpde.js",
   "scripts": {
     "geoSegment": "node geoSegment/geoSegment.js",
-    "lint": "eslint geoSegment/**/*.js",
+    "lint": "eslint 'geoSegment/**/*.js'",
     "test": "npm run lint && tsc"
   },
   "repository": {


### PR DESCRIPTION
[Why you should always quote your globs in NPM scripts.](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784)

I was wondering why ESLint wasn't running on geoSegment/geoSegment.js - this fixes it